### PR TITLE
add distingore to ignore files to distribute

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,7 @@
+/.wordpress-org
+/.git
+/.github
+
+.distignore
+.gitignore
+.gitattributes


### PR DESCRIPTION
Ignore everything that isn't part of the plugin itself